### PR TITLE
fix: Delegates use subclasses of DiscreteState

### DIFF
--- a/model-api/src/main/java/org/trainbeans/model/api/AbstractDelegatingDiscreteStateElement.java
+++ b/model-api/src/main/java/org/trainbeans/model/api/AbstractDelegatingDiscreteStateElement.java
@@ -22,18 +22,19 @@ import org.trainbeans.beans.VetoableBean;
 /**
  *
  * @author rhwood
+ * @param <S> type of state
  * @param <E> type of element
  * @param <D> type of delegate
  */
 @SuppressWarnings("linelength") // generic definitions on single line
-public abstract class AbstractDelegatingDiscreteStateElement<E extends DelegatingElement & DiscreteStateElement, D extends DiscreteStateDelegate<E>>
+public abstract class AbstractDelegatingDiscreteStateElement<S extends DiscreteState, E extends DelegatingElement & DiscreteStateElement<S>, D extends DiscreteStateDelegate<S, E>>
         extends VetoableBean
-        implements DelegatingElement<E, D>, DiscreteStateElement {
+        implements DelegatingElement<E, D>, DiscreteStateElement<S> {
 
     /**
      * The state if not handled by a delegate.
      */
-    private DiscreteState state;
+    private S state;
     /**
      * The delegate; if not null, most property access defers to the delegate.
      */
@@ -100,7 +101,7 @@ public abstract class AbstractDelegatingDiscreteStateElement<E extends Delegatin
      * {@inheritDoc}
      */
     @Override
-    public DiscreteState getState() {
+    public S getState() {
         return delegate != null ? delegate.getState() : state;
     }
 
@@ -108,7 +109,7 @@ public abstract class AbstractDelegatingDiscreteStateElement<E extends Delegatin
      * {@inheritDoc}
      */
     @Override
-    public DiscreteState getRequestedState() {
+    public S getRequestedState() {
         return delegate != null ? delegate.getRequestedState() : state;
     }
 
@@ -116,9 +117,9 @@ public abstract class AbstractDelegatingDiscreteStateElement<E extends Delegatin
      * {@inheritDoc}
      */
     @Override
-    public AbstractDelegatingDiscreteStateElement<E, D>
-            setState(final DiscreteState newState) {
-        DiscreteState oldState = state;
+    public <T extends DiscreteStateElement> T
+            setState(final S newState) {
+        S oldState = state;
         state = newState;
         if (delegate != null) {
             delegate.setState(newState);
@@ -163,7 +164,7 @@ public abstract class AbstractDelegatingDiscreteStateElement<E extends Delegatin
      * @param newState the new state
      */
     // package protected for unit testing
-    void setNonDelegatedState(final DiscreteState newState) {
+    void setNonDelegatedState(final S newState) {
         this.state = newState;
     }
 }

--- a/model-api/src/main/java/org/trainbeans/model/api/AbstractDiscreteStateDelegate.java
+++ b/model-api/src/main/java/org/trainbeans/model/api/AbstractDiscreteStateDelegate.java
@@ -19,15 +19,16 @@ import org.trainbeans.beans.VetoableBean;
 
 /**
  * This is a simplistic abstract delegate for {@link DiscreteStateElement}s that
- * is primarily useful for simulation and unit testing. Other implementations of
- * {@link DiscreteStateDelegate} can use this as a template.
+ * is primarily useful for simulation and unit testing.Other implementations of
+ {@link DiscreteStateDelegate} can use this as a template.
  *
  * @author rhwood
+ * @param <S> the type of supported state
  * @param <E> the type of supported element
  */
 @SuppressWarnings("checkstyle:linelength") // generic definition on one line
-public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement & DiscreteStateElement>
-        extends VetoableBean implements DiscreteStateDelegate<E> {
+public abstract class AbstractDiscreteStateDelegate<S extends DiscreteState, E extends DelegatingElement & DiscreteStateElement<S>>
+        extends VetoableBean implements DiscreteStateDelegate<S, E> {
 
     /**
      * The delegating element.
@@ -41,7 +42,7 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
     /**
      * The current state.
      */
-    private DiscreteState state;
+    private S state;
 
     /**
      * Test if the provided name is valid in this context.
@@ -79,14 +80,14 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
      * {@inheritDoc}
      */
     @Override
-    public <D extends Element> D setName(final String name) {
-        String oldName = this.name;
-        if (isValidName(name)) {
-            this.name = name;
+    public <D extends Element> D setName(final String newName) {
+        String oldName = name;
+        if (isValidName(newName)) {
+            name = newName;
         } else {
             throw new IllegalArgumentException();
         }
-        firePropertyChange("name", oldName, name);
+        firePropertyChange("name", oldName, newName);
         return getSelf();
     }
 
@@ -94,7 +95,7 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
      * {@inheritDoc}
      */
     @Override
-    public DiscreteState getState() {
+    public S getState() {
         return state;
     }
 
@@ -103,7 +104,7 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
      */
     @Override
     public <D extends DiscreteStateElement> D
-            setState(final DiscreteState newState) {
+            setState(final S newState) {
         DiscreteState oldState = state;
         state = newState;
         firePropertyChange("state", oldState, newState);
@@ -114,7 +115,7 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
      * {@inheritDoc}
      */
     @Override
-    public DiscreteState getRequestedState() {
+    public S getRequestedState() {
         return getState();
     }
 

--- a/model-api/src/main/java/org/trainbeans/model/api/AbstractDiscreteStateDelegate.java
+++ b/model-api/src/main/java/org/trainbeans/model/api/AbstractDiscreteStateDelegate.java
@@ -79,7 +79,7 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
      * {@inheritDoc}
      */
     @Override
-    public AbstractDiscreteStateDelegate<E> setName(final String name) {
+    public <D extends Element> D setName(final String name) {
         String oldName = this.name;
         if (isValidName(name)) {
             this.name = name;
@@ -87,7 +87,7 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
             throw new IllegalArgumentException();
         }
         firePropertyChange("name", oldName, name);
-        return this;
+        return getSelf();
     }
 
     /**
@@ -102,12 +102,12 @@ public abstract class AbstractDiscreteStateDelegate<E extends DelegatingElement 
      * {@inheritDoc}
      */
     @Override
-    public AbstractDiscreteStateDelegate<E>
+    public <D extends DiscreteStateElement> D
             setState(final DiscreteState newState) {
         DiscreteState oldState = state;
         state = newState;
         firePropertyChange("state", oldState, newState);
-        return this;
+        return getSelf();
     }
 
     /**

--- a/model-api/src/main/java/org/trainbeans/model/api/DiscreteStateDelegate.java
+++ b/model-api/src/main/java/org/trainbeans/model/api/DiscreteStateDelegate.java
@@ -18,9 +18,10 @@ package org.trainbeans.model.api;
 /**
  *
  * @author rhwood
- * @param <T> the type of Element being delegated
+ * @param <S> the type of supported state
+ * @param <D> the type of Element being delegated
  */
-public interface DiscreteStateDelegate<T extends DelegatingElement
-        & DiscreteStateElement> extends Delegate<T>, DiscreteStateElement {
+@SuppressWarnings("linelength") // generic definitions on single line
+public interface DiscreteStateDelegate<S extends DiscreteState, D extends DelegatingElement & DiscreteStateElement<S>> extends Delegate<D>, DiscreteStateElement<S> {
 
 }

--- a/model-api/src/main/java/org/trainbeans/model/api/DiscreteStateElement.java
+++ b/model-api/src/main/java/org/trainbeans/model/api/DiscreteStateElement.java
@@ -20,15 +20,16 @@ package org.trainbeans.model.api;
  * integers.
  *
  * @author rhwood
+ * @param <S> the supported subclass of DiscreteState
  */
-public interface DiscreteStateElement extends Element {
+public interface DiscreteStateElement<S extends DiscreteState> extends Element {
 
     /**
      * Get the state.
      *
      * @return the state
      */
-    DiscreteState getState();
+    S getState();
 
     /**
      * Set the state.
@@ -37,7 +38,7 @@ public interface DiscreteStateElement extends Element {
      * @param state the state to set
      * @return this object
      */
-    <T extends DiscreteStateElement> T setState(DiscreteState state);
+    <T extends DiscreteStateElement> T setState(S state);
 
     /**
      * Get the the state that was last set. This may differ from
@@ -48,5 +49,5 @@ public interface DiscreteStateElement extends Element {
      *
      * @return the requested set
      */
-    DiscreteState getRequestedState();
+    S getRequestedState();
 }

--- a/model-api/src/main/java/org/trainbeans/model/api/Turnout.java
+++ b/model-api/src/main/java/org/trainbeans/model/api/Turnout.java
@@ -19,8 +19,8 @@ package org.trainbeans.model.api;
  *
  * @author rhwood
  */
-public final class Turnout extends
-        AbstractDelegatingDiscreteStateElement<Turnout, TurnoutDelegate> {
+@SuppressWarnings("linelength") // generic definitions on single line
+public final class Turnout extends AbstractDelegatingDiscreteStateElement<Turnout.State, Turnout, TurnoutDelegate> {
 
     public enum State implements DiscreteState {
         /**

--- a/model-api/src/main/java/org/trainbeans/model/api/TurnoutDelegate.java
+++ b/model-api/src/main/java/org/trainbeans/model/api/TurnoutDelegate.java
@@ -19,6 +19,7 @@ package org.trainbeans.model.api;
  *
  * @author rhwood
  */
-public interface TurnoutDelegate extends DiscreteStateDelegate<Turnout> {
+@SuppressWarnings("linelength") // generic definitions on single line
+public interface TurnoutDelegate extends DiscreteStateDelegate<Turnout.State, Turnout> {
 
 }

--- a/model-api/src/test/java/org/trainbeans/model/api/TurnoutDelegateTest.java
+++ b/model-api/src/test/java/org/trainbeans/model/api/TurnoutDelegateTest.java
@@ -72,7 +72,7 @@ class TurnoutDelegateTest extends AbstractDiscreteStateDelegateTest<Turnout, Tur
         // no need to test, tested in TurnoutTest#testGetRequestedState()
     }
     
-    private class TurnoutDelegateImpl extends AbstractDiscreteStateDelegate<Turnout> implements TurnoutDelegate {
+    private class TurnoutDelegateImpl extends AbstractDiscreteStateDelegate<Turnout.State, Turnout> implements TurnoutDelegate {
 
         @Override
         protected boolean isValidName(String name) {

--- a/model-api/src/test/java/org/trainbeans/model/api/TurnoutTest.java
+++ b/model-api/src/test/java/org/trainbeans/model/api/TurnoutTest.java
@@ -91,7 +91,7 @@ class TurnoutTest extends AbstractDelegatingDiscreteStateElementTest<Turnout, Tu
         assertThat(lastEvent.getNewValue()).isEqualTo(Turnout.State.THROWN);
     }
 
-    private static class TestTurnoutDelegate extends AbstractDiscreteStateDelegate<Turnout> implements TurnoutDelegate {
+    private static class TestTurnoutDelegate extends AbstractDiscreteStateDelegate<Turnout.State, Turnout> implements TurnoutDelegate {
 
         TestTurnoutDelegate() {
             setState(Turnout.State.UNKNOWN);

--- a/model/src/test/java/org/trainbeans/model/impl/TurnoutFactoryTest.java
+++ b/model/src/test/java/org/trainbeans/model/impl/TurnoutFactoryTest.java
@@ -66,7 +66,7 @@ class TurnoutFactoryTest {
         assertThat(factory.create("test", lookup).getName()).isEqualTo("test");
     }
     
-    private static class TestTurnoutDelegate extends AbstractDiscreteStateDelegate<Turnout> implements TurnoutDelegate {
+    private static class TestTurnoutDelegate extends AbstractDiscreteStateDelegate<Turnout.State, Turnout> implements TurnoutDelegate {
 
         @Override
         protected boolean isValidName(String name) {


### PR DESCRIPTION
This adds some complexity to subclassing, but provides delegates with a specific state to manipulate without casting.